### PR TITLE
Allows ranged mobs to use modded versions of their ranged weapons

### DIFF
--- a/src/main/java/tallestegg/bigbrain/mixins/LivingEntityMixin.java
+++ b/src/main/java/tallestegg/bigbrain/mixins/LivingEntityMixin.java
@@ -1,7 +1,10 @@
 package tallestegg.bigbrain.mixins;
 
 import java.util.UUID;
+import java.util.function.Predicate;
 
+import net.minecraft.item.Item;
+import net.minecraft.item.ShootableItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
@@ -132,4 +135,15 @@ public abstract class LivingEntityMixin extends Entity implements IBucklerUser {
 
     @Shadow
     protected abstract boolean isActiveItemStackBlocking();
+
+    @Shadow public abstract boolean func_233634_a_(Predicate<Item> itemPredicate);
+
+    @Inject(at = @At("HEAD"), method = "canEquip", cancellable = true)
+    private void betterIsHolding(Item itemIn, CallbackInfoReturnable<Boolean> cir){
+        if(itemIn instanceof ShootableItem){
+            Class<? extends Item> itemInClass = itemIn.getClass();
+            Predicate<Item> itemPredicate = testItem -> testItem.getClass().isAssignableFrom(itemInClass);
+            cir.setReturnValue(this.func_233634_a_(itemPredicate));
+        }
+    }
 }

--- a/src/main/java/tallestegg/bigbrain/mixins/ProjectileHelperMixin.java
+++ b/src/main/java/tallestegg/bigbrain/mixins/ProjectileHelperMixin.java
@@ -1,0 +1,27 @@
+package tallestegg.bigbrain.mixins;
+
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.projectile.ProjectileHelper;
+import net.minecraft.item.Item;
+import net.minecraft.item.ShootableItem;
+import net.minecraft.util.Hand;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Predicate;
+
+@Mixin(ProjectileHelper.class)
+public abstract class ProjectileHelperMixin {
+
+    @Inject(at = @At("HEAD"), method = "getHandWith", cancellable = true)
+    private static void betterGetWeaponHoldingHand(LivingEntity living, Item itemIn, CallbackInfoReturnable<Hand> cir){
+        if(itemIn instanceof ShootableItem){
+            Class<? extends Item> itemInClass = itemIn.getClass();
+            Predicate<Item> itemPredicate = testItem -> testItem.getClass().isAssignableFrom(itemInClass);
+            Hand handWithItem = itemPredicate.test(living.getHeldItemMainhand().getItem()) ? Hand.MAIN_HAND : Hand.OFF_HAND;
+            cir.setReturnValue(handWithItem);
+        }
+    }
+}

--- a/src/main/resources/bigbrain.mixins.json
+++ b/src/main/resources/bigbrain.mixins.json
@@ -4,19 +4,20 @@
   "compatibilityLevel": "JAVA_8",
   "refmap": "bigbrain.refmap.json",
   "mixins": [
-     "MeleeAttackGoalMixin",
-     "RangedCrossbowAttackGoalMixin",
-     "PlayerEntityMixin",
-     "BruteBrainMixin",
-     "PiglinBruteMixin",
-     "LivingEntityMixin",
-     "MovementControllerMixin",
-     "LookControllerMixin",
-     "PiglinBrainMixin"
+    "BruteBrainMixin",
+    "LivingEntityMixin",
+    "LookControllerMixin",
+    "MeleeAttackGoalMixin",
+    "MovementControllerMixin",
+    "PiglinBrainMixin",
+    "PiglinBruteMixin",
+    "PlayerEntityMixin",
+    "ProjectileHelperMixin",
+    "RangedCrossbowAttackGoalMixin"
   ],
   "client": [
-     "PlayerModelMixin",
-     "MouseHelperMixin"
+    "MouseHelperMixin",
+    "PlayerModelMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Adds 1 mixin for ProjectileHelper and an additional injection (w/ shadow method) to LivingEntity.

Bow/Crossbow-using mobs use ProjectileHelper.getHandWith(Item) and LivingEntity.canEquip(Item), which isn't ideal if you want them to use a modded ranged weapon. This PR converts those hardcoded item checks into checking if an item is assignable from the class of the item passed in, serving as the equivalent of an instanceof check.

Forge already added field-to-instanceof transformers for the various other hardcoded item checks as needed so these are the only two changes required.

I also plan to submit a PR that adds the equivalent of this to Forge, so use this Mixin as a temporary fix until it possibly gets merged.